### PR TITLE
Tile inside the work area so windows don't overlap the taskbar

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -81,7 +81,8 @@ fn create_overlay_window(screen_size: Size) -> (iced::window::Id, Task<Message>)
 impl State {
     pub fn new() -> (Self, Task<Message>) {
         let screen_size = system::screen_size().expect("Screen size retrieval");
-        let tiler = ScrollTiler::new(10.0, 20.0, screen_size);
+        let work_area = system::work_area().expect("Work area retrieval");
+        let tiler = ScrollTiler::new(10.0, 20.0, work_area);
         let (overlay_window_id, overlay_window_creation_task) = create_overlay_window(screen_size);
         (
             Self {

--- a/src/app/service/overview/mod.rs
+++ b/src/app/service/overview/mod.rs
@@ -50,7 +50,7 @@ impl app::State {
 
         let thumbnails_data = thumbnail::compute_thumbnails_bounds_from_tiler_windows(
             &windows_data,
-            self.tiler.screen_size(),
+            self.tiler.work_area().size(),
             10.0,
         );
 

--- a/src/app/service/overview/thumbnail.rs
+++ b/src/app/service/overview/thumbnail.rs
@@ -35,13 +35,13 @@ pub struct WindowData {
 
 pub fn compute_thumbnails_bounds_from_tiler_windows(
     windows: &[WindowData],
-    screen_size: Size,
+    tiler_area: Size,
     padding: f32,
 ) -> Vec<ThumbnailData> {
     // Width of packed windows
     let total_tiler_width = windows.iter().map(|w| w.width + padding).sum::<f32>() - padding;
 
-    let reduction_ratio = screen_size.width() / total_tiler_width;
+    let reduction_ratio = tiler_area.width() / total_tiler_width;
 
     debug!("total tiler width including padding: {total_tiler_width}");
     debug!("Thumbnail reduction ratio for packing windows: {reduction_ratio}");
@@ -60,10 +60,10 @@ pub fn compute_thumbnails_bounds_from_tiler_windows(
     let mut current_x = 0.0;
     let mut thumbnails = Vec::new();
 
-    let thumbnail_height = reduction_ratio * screen_size.height();
-    let thumbnail_y = (screen_size.height() - thumbnail_height).abs() / 2.0;
+    let thumbnail_height = reduction_ratio * tiler_area.height();
+    let thumbnail_y = (tiler_area.height() - thumbnail_height).abs() / 2.0;
     let thumbnail_x_center_offset =
-        (screen_size.width() - reduction_ratio * total_tiler_width).abs() / 2.0;
+        (tiler_area.width() - reduction_ratio * total_tiler_width).abs() / 2.0;
 
     for window in windows {
         let width = reduction_ratio * window.width;

--- a/src/scroll_tiler.rs
+++ b/src/scroll_tiler.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use joy_error::log::ResultLogExt;
 use log::{debug, info, warn};
 
-use crate::{cast, utils::math::Size, window::Window};
+use crate::{cast, utils::math::Bounds, window::Window};
 
 /// Represents a window managed by the tiler.
 #[derive(PartialEq)]
@@ -48,18 +48,20 @@ pub struct ScrollTiler {
     resize_increment: f32,
     /// The current scroll offset. Used to scroll the tiler view horizontally.
     scroll_offset: f32,
-    /// The size of the screen where the tiler is applied.
-    screen_size: Size,
+    /// The work area of the screen the tiler is applied to: the screen
+    /// rectangle minus the taskbar and any other docked AppBars. Tiling stays
+    /// inside this rectangle so windows do not overlap the taskbar.
+    work_area: Bounds,
     /// The index of the previously focused window. Used as a fallback when the focused window is not tiled.
     previously_focused_window_index: Option<usize>,
 }
 
 impl ScrollTiler {
-    pub fn new(padding: f32, resize_increment: f32, screen_size: Size) -> Self {
+    pub fn new(padding: f32, resize_increment: f32, work_area: Bounds) -> Self {
         Self {
             padding,
             resize_increment,
-            screen_size,
+            work_area,
             ..Default::default()
         }
     }
@@ -165,8 +167,8 @@ impl ScrollTiler {
 
     pub fn set_current_window_halfscreen(&mut self) {
         if let Some(focus_index) = self.focus_index() {
-            let screen_width = self.screen_size.width();
-            self.windows[focus_index].request_width(self.padding.mul_add(-2.0, screen_width / 2.0));
+            let work_width = self.work_area.size().width();
+            self.windows[focus_index].request_width(self.padding.mul_add(-2.0, work_width / 2.0));
         }
     }
 
@@ -179,7 +181,7 @@ impl ScrollTiler {
     }
 
     pub fn max_screen_width(&self) -> f32 {
-        self.padding.mul_add(-2.0, self.screen_size.width()) - 1.0
+        self.padding.mul_add(-2.0, self.work_area.size().width()) - 1.0
     }
 
     /// Resize the current window width by the resize increment in the given direction.
@@ -195,7 +197,7 @@ impl ScrollTiler {
                 .mul_add(direction, self.windows[focus_index].width)
                 .clamp(
                     0.0,
-                    self.padding.mul_add(-2.0, self.screen_size().width()) - 1.0,
+                    self.padding.mul_add(-2.0, self.work_area.size().width()) - 1.0,
                 );
             self.windows[focus_index].request_width(new_width);
         }
@@ -274,15 +276,16 @@ impl ScrollTiler {
     }
 
     fn default_size(&self) -> f32 {
-        self.padding.mul_add(-2.0, self.screen_size.width() / 2.0)
+        self.padding.mul_add(-2.0, self.work_area.size().width() / 2.0)
     }
 
     fn layout_windows(&mut self, windows_positions: &[f32]) {
+        let origin = self.work_area.position();
+        let height = self.padding.mul_add(-2.0, self.work_area.size().height());
         for (window, x) in self.windows.iter_mut().zip(windows_positions) {
-            let y = self.padding;
-            let height = self.padding.mul_add(-2.0, self.screen_size.height());
+            let y = origin.y() + self.padding;
             if let Err(e) = window.inner.move_to(
-                [x - self.scroll_offset, y].into(),
+                [origin.x() + x - self.scroll_offset, y].into(),
                 [window.width, height].into(),
             ) {
                 warn!(
@@ -322,13 +325,13 @@ impl ScrollTiler {
                 .padding
                 .mul_add(2.0, focused_window_left + focused_window.width);
 
-            if focused_window_left >= 0.0 && focused_window_right <= self.screen_size.width() {
+            let work_width = self.work_area.size().width();
+            if focused_window_left >= 0.0 && focused_window_right <= work_width {
                 return;
             }
 
             let window_left_to_screen_left = focused_window_left.abs();
-            let window_right_to_screen_right =
-                focused_window_right.sub(self.screen_size.width()).abs();
+            let window_right_to_screen_right = focused_window_right.sub(work_width).abs();
 
             if window_left_to_screen_left < window_right_to_screen_right {
                 self.scroll_offset -= window_left_to_screen_left;
@@ -351,7 +354,7 @@ impl ScrollTiler {
         positions
     }
 
-    pub const fn screen_size(&self) -> Size {
-        self.screen_size
+    pub const fn work_area(&self) -> Bounds {
+        self.work_area
     }
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,5 +1,6 @@
 use log::warn;
 use windows::Win32::{
+    Foundation::RECT,
     Graphics::Gdi::{COLOR_HIGHLIGHT, GetSysColor},
     UI::{
         Input::KeyboardAndMouse::{
@@ -8,13 +9,14 @@ use windows::Win32::{
         },
         WindowsAndMessaging::{
             GetDesktopWindow, GetSystemMetrics, IDYES, MB_OK, MB_YESNO, SM_CXSCREEN, SM_CYSCREEN,
+            SPI_GETWORKAREA, SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS, SystemParametersInfoW,
         },
     },
 };
 
 use crate::{
-    utils::math::{Position, Size},
-    winapi, wincall_into_result,
+    utils::math::{Bounds, Position, Size},
+    winapi, wincall_into_result, wincall_result,
     window::{self, Window},
 };
 
@@ -27,6 +29,20 @@ pub fn screen_size() -> anyhow::Result<Size> {
         wincall_into_result!(GetSystemMetrics(SM_CXSCREEN))? as f32,
         wincall_into_result!(GetSystemMetrics(SM_CYSCREEN))? as f32,
     ]))
+}
+
+/// Primary monitor's work area: screen rectangle minus the taskbar and any
+/// other docked AppBars. Tiling inside this rectangle keeps windows from
+/// overlapping the taskbar regardless of which edge it sits on.
+pub fn work_area() -> anyhow::Result<Bounds> {
+    let mut rect = RECT::default();
+    wincall_result!(SystemParametersInfoW(
+        SPI_GETWORKAREA,
+        0,
+        Some(std::ptr::from_mut::<RECT>(&mut rect).cast::<std::ffi::c_void>()),
+        SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS(0),
+    ))?;
+    Ok(rect.into())
 }
 
 pub fn highlight_color() -> anyhow::Result<iced::Color> {

--- a/src/utils/math.rs
+++ b/src/utils/math.rs
@@ -3,7 +3,7 @@ use joy_vector::gen_vector;
 gen_vector!(Position<f32, 2> with two_dim);
 gen_vector!(Size<f32, 2> with two_dim);
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct Bounds {
     pub left: f32,
     pub top: f32,


### PR DESCRIPTION
Closes #64.

Tiled windows now sit above the taskbar instead of covering it.

The tiler used `GetSystemMetrics(SM_CXSCREEN/SM_CYSCREEN)` for its bounds, which returns the full primary monitor including the taskbar area. Switched it to `SystemParametersInfoW(SPI_GETWORKAREA, ...)`, which returns the work area Windows already computes to exclude the taskbar and any other docked AppBars.

The tiler now stores a `Bounds` rect (origin + size) instead of a `Size`, and applies the rect's origin when positioning windows. Works for top, bottom, left, or right taskbars.

The iced overlay window keeps using the full screen on purpose, so its internal coordinate system still matches the absolute Win32 screen coords used by `DwmGetWindowAttribute` for highlight rendering.

Tested locally on Windows 11 with the default bottom taskbar. First time contributing to an OSS project, so let me know if anything is off. Loving Winri so far.